### PR TITLE
fix: check if worksheet has datas

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -61,6 +61,7 @@ class Data:
             or os.path.isfile(
                 f"{self.output_path}/membros-ativos-verbas-indenizatorias-{self.month}-{self.year}.xlsx"
             )
+        #Quando uma planilha sem dados é baixada, ela possui sempre duas linhas (com dados NaN e decimais iguais a 0.00).
         ) or (len(self.contracheque == 2) or len(self.indenizatorias)==2):
             sys.stderr.write(f"Não existe planilhas para {self.month}/{self.year}.")
             sys.exit(STATUS_DATA_UNAVAILABLE)

--- a/src/data.py
+++ b/src/data.py
@@ -61,7 +61,7 @@ class Data:
             or os.path.isfile(
                 f"{self.output_path}/membros-ativos-verbas-indenizatorias-{self.month}-{self.year}.xlsx"
             )
-        ):
+        ) or (len(self.contracheque == 2) or len(self.indenizatorias)==2):
             sys.stderr.write(f"Não existe planilhas para {self.month}/{self.year}.")
             sys.exit(STATUS_DATA_UNAVAILABLE)
 


### PR DESCRIPTION
Essa alteração foi uma solução encontrada para descobrir se a planilha recebida pela entrada padrão possui dados ou não. No site do mpms, uma planilha é baixada mesmo quando não possui dados nela. Quando essa planilha sem dados é baixada, ela possui sempre duas linhas (com dados NaN e decimais iguais a 0.00). A solução encontrada para o parser não mapear esse tipo de planilha, foi verificar a quantidade de linhas que ela possui. Caso a planilha possua apenas 2 linhas, significa que não possui dados.